### PR TITLE
Add git_utils.py to .dockerignore to prevent it from being ignored

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !Dockerfile
 !requirements.txt
 !AndroidResourceTranslator.py
+!git_utils.py


### PR DESCRIPTION
This pull request includes a small change to the `.dockerignore` file. The change ensures that `git_utils.py` is not ignored by Docker.

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R8): Added `git_utils.py` to the list of files not ignored by Docker.