### PR TITLE
Update action yml default values

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 !Dockerfile
 !requirements.txt
 !AndroidResourceTranslator.py
+!git_utils.py

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: "Comma-separated paths to the Android resource directories (e.g., './app/src/main/res, ./library/src/main/res')."
     required: false
     default: "${{ github.workspace }}"
-  auto_translate:
-    description: "Automatically translate missing resources. Set to 'true' to enable."
-    required: false
-    default: "true"
   log_trace:
     description: "Enable detailed logging. Set to 'true' to enable."
     required: false
@@ -26,7 +22,7 @@ inputs:
   openai_model:
     description: "Specify the OpenAI model to use for translation."
     required: false
-    default: "gpt-3.5-turbo"
+    default: "gpt-4o-mini"
   project_context:
     description: "Additional project context to include in translation prompts."
     required: false
@@ -34,7 +30,7 @@ inputs:
   ignore_folders:
     description: "Comma-separated list of folder names to ignore during resource scanning (e.g., build)."
     required: false
-    default: "build"
+    default: ""
 
 outputs:
   translation_report:


### PR DESCRIPTION
This pull request includes changes to the `.dockerignore` and `action.yml` files to update the ignored files and modify the inputs for the GitHub Action workflow. The most important changes are:

### Updates to ignored files:

* Added `git_utils.py` to the list of files that should not be ignored by Docker. (.dockerignore)

### Modifications to GitHub Action inputs:

* Removed the `auto_translate` input, which previously allowed automatic translation of missing resources. (`action.yml`)
* Changed the default OpenAI model for translation from `gpt-3.5-turbo` to `gpt-4o-mini`. (`action.yml`)
* Updated the default value of `ignore_folders` from `build` to an empty string, indicating no folders are ignored by default. (`action.yml`)