### PR TITLE
refactor: Replace auto translate arg with dry-run mode

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -103,18 +103,17 @@ The [`sample_project/`](../sample_project/) directory contains a realistic Andro
 
 **Quick Test - Dry Run:**
 ```bash
-python app/AndroidResourceTranslator.py sample_project/
+python app/AndroidResourceTranslator.py sample_project/ --dry-run
 ```
 
-**Test Auto-translation:**
+**Test Translation:**
 ```bash
-python app/AndroidResourceTranslator.py sample_project/ --auto-translate
+python app/AndroidResourceTranslator.py sample_project/
 ```
 
 **Test with OpenRouter (Gemini):**
 ```bash
 python app/AndroidResourceTranslator.py sample_project/ \
-    --auto-translate \
     --llm-provider openrouter \
     --model google/gemini-2.5-flash-preview-09-2025
 ```
@@ -122,7 +121,6 @@ python app/AndroidResourceTranslator.py sample_project/ \
 **Test with Project Context:**
 ```bash
 python app/AndroidResourceTranslator.py sample_project/ \
-    --auto-translate \
     --project-context "A shopping list mobile application"
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ We recommend the model google/gemini-2.5-flash-preview-09-2025 as it got the bes
 To run the translator on your local machine, execute:
 
 ```bash
-python AndroidResourceTranslator.py /path/to/your/android/project --auto-translate
+python AndroidResourceTranslator.py /path/to/your/android/project
 ```
 
-You can also pass additional parameters like `--project-context` and `--validate-translations` as needed.
+You can also pass additional parameters like `--project-context`, `--validate-translations`, or `--dry-run` (to only check for missing translations without translating) as needed.
 
 ## Configuration
 
@@ -122,7 +122,7 @@ The action supports the following inputs:
 | Input                        | Description                                                                                                                                                                                                                                    | Default Value                                                          | Optional | Example                                                                |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
 | **resources_paths**          | Paths to the Android resource directories. Typically includes directories such as `app/src/main/res`, `library/src/main/res`, etc. If not provided, this action will search throughout the entire project folder.                         | `${{ github.workspace }}`                                              | Yes      | `./app/src/main/res, ./library/src/main/res, ./feature/src/main/res`   |
-| **auto_translate**           | Automatically translate missing resources. Set it to `false` to disable auto-translation.                                                                                                                                                        | `"true"`                                                               | Yes      | `"true"` or `"false"`                                                  |
+| **dry_run**                  | Run in dry-run mode (only report missing translations without translating). Set to `"true"` to enable dry-run mode.                                                                                                                           | `"false"`                                                              | Yes      | `"true"` or `"false"`                                                  |
 | **validate_translations**    | Enable manual validation of translations before saving. When enabled, you will be prompted to confirm each translation.                                                                                                                   | `"false"`                                                              | Yes      | `"true"` or `"false"`                                                  |
 | **log_trace**                | Enable detailed logging. Use `"true"` for verbose output.                                                                                                                                                                                     | `"false"`                                                              | Yes      | `"true"`                                                               |
 | **llm_provider**             | LLM provider to use for translation. Options are `"openai"` or `"openrouter"`.                                                                                                                                                                 | `"openrouter"`                                                             | Yes      | `"openai"`, `"openrouter"`                                              |

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Android Resource Translator"
-description: "Checks Android resource files for missing translations and auto-translates using OpenAI or OpenRouter."
+description: "Checks Android resource files for missing translations and automatically translates them using OpenAI or OpenRouter."
 author: "DuarteBarbosaDev"
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,10 @@ inputs:
     description: "Comma-separated paths to the Android resource directories (e.g., './app/src/main/res, ./library/src/main/res')."
     required: false
     default: "${{ github.workspace }}"
-  auto_translate:
-    description: "Automatically translate missing resources. Set to 'true' to enable."
+  dry_run:
+    description: "Run in dry-run mode (only report missing translations without translating). Set to 'true' to enable dry-run mode."
     required: false
-    default: "true"
+    default: "false"
   log_trace:
     description: "Enable detailed logging. Set to 'true' to enable."
     required: false

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -1433,9 +1433,7 @@ def main() -> None:
             if resources_paths_input
             else []
         )
-        dry_run = (
-            os.environ.get("INPUT_DRY_RUN", "false").lower() == "true"
-        )
+        dry_run = os.environ.get("INPUT_DRY_RUN", "false").lower() == "true"
         # No manual validation on GitHub; force it off.
         validate_translations = False
         log_trace = os.environ.get("INPUT_LOG_TRACE", "false").lower() == "true"
@@ -1595,10 +1593,7 @@ def main() -> None:
 
         # API Keys - determine based on provider (strict matching)
         if llm_provider == "openrouter":
-            api_key = (
-                args.openrouter_api_key
-                or os.environ.get("OPENROUTER_API_KEY")
-            )
+            api_key = args.openrouter_api_key or os.environ.get("OPENROUTER_API_KEY")
         else:
             api_key = args.openai_api_key or os.environ.get("OPENAI_API_KEY")
 
@@ -1626,27 +1621,33 @@ def main() -> None:
 
     # Early validation: Check API key if not in dry-run mode
     if not dry_run and not api_key:
-        env_var_name = "OPENROUTER_API_KEY" if llm_provider == "openrouter" else "OPENAI_API_KEY"
-        print(f"\n========================================")
-        print(f"ERROR: API key not found!")
-        print(f"========================================")
-        print(f"Translation is enabled (not in dry-run mode) but no API key was provided.")
-        print(f"\nTo fix this:")
-        print(f"\n1. For GitHub Actions, add {env_var_name} to your repository secrets:")
-        print(f"   - Go to Settings > Secrets and variables > Actions")
+        env_var_name = (
+            "OPENROUTER_API_KEY" if llm_provider == "openrouter" else "OPENAI_API_KEY"
+        )
+        print("\n========================================")
+        print("ERROR: API key not found!")
+        print("========================================")
+        print(
+            "Translation is enabled (not in dry-run mode) but no API key was provided."
+        )
+        print("\nTo fix this:")
+        print(
+            f"\n1. For GitHub Actions, add {env_var_name} to your repository secrets:"
+        )
+        print("   - Go to Settings > Secrets and variables > Actions")
         print(f"   - Add a new secret named: {env_var_name}")
-        print(f"   - Pass it via env in your workflow:")
-        print(f"     env:")
+        print("   - Pass it via env in your workflow:")
+        print("     env:")
         print(f"       {env_var_name}: ${{{{ secrets.{env_var_name} }}}}")
-        print(f"\n2. For local execution, set the environment variable:")
+        print("\n2. For local execution, set the environment variable:")
         print(f"   export {env_var_name}=your_key_here")
-        print(f"\n3. Or pass it as a command-line argument:")
+        print("\n3. Or pass it as a command-line argument:")
         print(f"   --{llm_provider}-api-key YOUR_KEY")
         if llm_provider == "openrouter":
-            print(f"\nGet your API key at: https://openrouter.ai/keys")
+            print("\nGet your API key at: https://openrouter.ai/keys")
         else:
-            print(f"\nGet your API key at: https://platform.openai.com/api-keys")
-        print(f"========================================\n")
+            print("\nGet your API key at: https://platform.openai.com/api-keys")
+        print("========================================\n")
         sys.exit(1)
 
     if not resources_paths:
@@ -1708,9 +1709,7 @@ def main() -> None:
             logger.error(f"Error creating LLM configuration: {e}")
             sys.exit(1)
 
-        logger.info(
-            f"Starting translation using {llm_provider} with model {model}"
-        )
+        logger.info(f"Starting translation using {llm_provider} with model {model}")
         translation_log = auto_translate_resources(
             merged_modules,
             llm_config,

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Android Resource Translation Checker & Auto-Translator
+Android Resource Auto-Translator
 
 This script scans Android resource files (strings.xml) for string and plural resources,
 reports missing translations, and can automatically translate missing entries using OpenAI.
@@ -1688,7 +1688,7 @@ def main() -> None:
             module.print_resources()
 
     translation_log = {}
-    # If not in dry-run mode, run the auto-translation process.
+    # If not in dry-run mode, run the translation process.
     if not dry_run:
         # Create LLM configuration
         try:
@@ -1709,7 +1709,7 @@ def main() -> None:
             sys.exit(1)
 
         logger.info(
-            f"Starting auto-translation using {llm_provider} with model {model}"
+            f"Starting translation using {llm_provider} with model {model}"
         )
         translation_log = auto_translate_resources(
             merged_modules,

--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -55,28 +55,28 @@ TRANSLATE_PLURAL_TOOL = {
             "properties": {
                 "one": {
                     "type": "string",
-                    "description": "Translation for singular quantity (e.g., '1 day')"
+                    "description": "Translation for singular quantity (e.g., '1 day')",
                 },
                 "other": {
                     "type": "string",
-                    "description": "Translation for other quantities (e.g., '%d days') - this is the default fallback"
+                    "description": "Translation for other quantities (e.g., '%d days') - this is the default fallback",
                 },
                 "zero": {
                     "type": "string",
-                    "description": "Translation for zero quantity if the target language requires it"
+                    "description": "Translation for zero quantity if the target language requires it",
                 },
                 "two": {
                     "type": "string",
-                    "description": "Translation for dual quantity if the target language requires it"
+                    "description": "Translation for dual quantity if the target language requires it",
                 },
                 "few": {
                     "type": "string",
-                    "description": "Translation for few quantity if the target language requires it (e.g., Slavic languages)"
+                    "description": "Translation for few quantity if the target language requires it (e.g., Slavic languages)",
                 },
                 "many": {
                     "type": "string",
-                    "description": "Translation for many quantity if the target language requires it (e.g., Slavic languages)"
-                }
+                    "description": "Translation for many quantity if the target language requires it (e.g., Slavic languages)",
+                },
             },
             "required": [],
             "additionalProperties": False,
@@ -193,7 +193,10 @@ class LLMClient:
         Returns:
             Dictionary of extra headers to include in requests
         """
-        if self.config.provider == LLMProvider.OPENROUTER and self.config.send_site_info:
+        if (
+            self.config.provider == LLMProvider.OPENROUTER
+            and self.config.send_site_info
+        ):
             headers = {}
 
             if self.config.site_url:

--- a/app/tests/test_integration.py
+++ b/app/tests/test_integration.py
@@ -116,9 +116,7 @@ class TestResourceFindingAndTranslation(TestIntegration):
 
         # Step 3: Perform auto-translation
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="fake_api_key",
-            model="fake_model"
+            provider=LLMProvider.OPENAI, api_key="fake_api_key", model="fake_model"
         )
 
         with patch("AndroidResourceTranslator.update_xml_file"):

--- a/app/tests/test_translation.py
+++ b/app/tests/test_translation.py
@@ -172,7 +172,9 @@ class TestSpecialCharacterEscaping(unittest.TestCase):
 
     def test_escape_apostrophes_integration_with_translate_text(self):
         """Test that translate_text properly escapes apostrophes in results."""
-        with patch("AndroidResourceTranslator.translate_with_llm") as mock_translate_with_llm:
+        with patch(
+            "AndroidResourceTranslator.translate_with_llm"
+        ) as mock_translate_with_llm:
             # Configure mock to return text with apostrophes
             mock_translate_with_llm.return_value = (
                 "Si us plau, activa Scrolless a la configuració d'accessibilitat."
@@ -180,9 +182,7 @@ class TestSpecialCharacterEscaping(unittest.TestCase):
 
             # Create LLMConfig
             llm_config = LLMConfig(
-                provider=LLMProvider.OPENAI,
-                api_key="test_api_key",
-                model="test-model"
+                provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
             )
 
             # Execute the function
@@ -201,7 +201,9 @@ class TestSpecialCharacterEscaping(unittest.TestCase):
 
     def test_escape_special_chars_integration_with_translate_text(self):
         """Test that translate_text properly escapes all special characters in results."""
-        with patch("AndroidResourceTranslator.translate_with_llm") as mock_translate_with_llm:
+        with patch(
+            "AndroidResourceTranslator.translate_with_llm"
+        ) as mock_translate_with_llm:
             # Configure mock to return text with multiple special characters
             mock_translate_with_llm.return_value = (
                 'Mensaje con "comillas", apóstrofo\', 25% y usuario@ejemplo.com'
@@ -209,9 +211,7 @@ class TestSpecialCharacterEscaping(unittest.TestCase):
 
             # Create LLMConfig
             llm_config = LLMConfig(
-                provider=LLMProvider.OPENAI,
-                api_key="test_api_key",
-                model="test-model"
+                provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
             )
 
             # Execute the function
@@ -230,15 +230,18 @@ class TestSpecialCharacterEscaping(unittest.TestCase):
 
     def test_escape_apostrophes_integration_with_translate_plural_text(self):
         """Test that translate_plural_text properly escapes apostrophes in results."""
-        with patch("AndroidResourceTranslator.translate_plural_with_llm") as mock_translate_plural_with_llm:
+        with patch(
+            "AndroidResourceTranslator.translate_plural_with_llm"
+        ) as mock_translate_plural_with_llm:
             # Configure mock with JSON plural response containing apostrophes
-            mock_translate_plural_with_llm.return_value = {"one": "%d element d'accessibilitat", "other": "%d elements d'accessibilitat"}
+            mock_translate_plural_with_llm.return_value = {
+                "one": "%d element d'accessibilitat",
+                "other": "%d elements d'accessibilitat",
+            }
 
             # Create LLMConfig
             llm_config = LLMConfig(
-                provider=LLMProvider.OPENAI,
-                api_key="test_api_key",
-                model="test-model"
+                provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
             )
 
             # Execute the function
@@ -259,15 +262,18 @@ class TestSpecialCharacterEscaping(unittest.TestCase):
 
     def test_escape_special_chars_integration_with_translate_plural_text(self):
         """Test that translate_plural_text properly escapes all special characters in results."""
-        with patch("AndroidResourceTranslator.translate_plural_with_llm") as mock_translate_plural_with_llm:
+        with patch(
+            "AndroidResourceTranslator.translate_plural_with_llm"
+        ) as mock_translate_plural_with_llm:
             # Configure mock with JSON plural response containing multiple special characters
-            mock_translate_plural_with_llm.return_value = {"one": '%d "elemento" al 50% en mi@correo', "other": '%d "elementos" al 50% en mi@correo'}
+            mock_translate_plural_with_llm.return_value = {
+                "one": '%d "elemento" al 50% en mi@correo',
+                "other": '%d "elementos" al 50% en mi@correo',
+            }
 
             # Create LLMConfig
             llm_config = LLMConfig(
-                provider=LLMProvider.OPENAI,
-                api_key="test_api_key",
-                model="test-model"
+                provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
             )
 
             # Execute the function
@@ -300,9 +306,7 @@ class TestTranslation(unittest.TestCase):
 
         # Create LLMConfig
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="test_api_key",
-            model="test-model"
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
         )
 
         # Execute the function
@@ -319,16 +323,16 @@ class TestTranslation(unittest.TestCase):
 
         # Verify API call parameters
         args = mock_translate_with_llm.call_args
-        self.assertIn("Hello World", args[0][0])  # Check text argument contains source text
+        self.assertIn(
+            "Hello World", args[0][0]
+        )  # Check text argument contains source text
         self.assertEqual(args[0][3], llm_config)  # Check correct LLMConfig
 
     def test_translate_text_empty_string(self, mock_translate_with_llm):
         """Test that empty strings are not sent to the API."""
         # Create LLMConfig
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="test_api_key",
-            model="test-model"
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
         )
 
         # Execute the function with empty input
@@ -345,9 +349,7 @@ class TestTranslation(unittest.TestCase):
 
         # Create LLMConfig
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="test_api_key",
-            model="test-model"
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
         )
 
         # Execute with project context
@@ -369,14 +371,17 @@ class TestTranslation(unittest.TestCase):
         """Test translating a plural resource with proper JSON response."""
         # The test needs to mock translate_plural_with_llm instead for plural translations
         # Configure mock with proper plural dict response
-        with patch("AndroidResourceTranslator.translate_plural_with_llm") as mock_translate_plural:
-            mock_translate_plural.return_value = {"one": "%d elemento", "other": "%d elementos"}
+        with patch(
+            "AndroidResourceTranslator.translate_plural_with_llm"
+        ) as mock_translate_plural:
+            mock_translate_plural.return_value = {
+                "one": "%d elemento",
+                "other": "%d elementos",
+            }
 
             # Create LLMConfig
             llm_config = LLMConfig(
-                provider=LLMProvider.OPENAI,
-                api_key="test_api_key",
-                model="test-model"
+                provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
             )
 
             # Execute the function
@@ -396,14 +401,14 @@ class TestTranslation(unittest.TestCase):
     def test_translate_plural_text_error(self, mock_translate_with_llm):
         """Test error handling when LLM API fails."""
         # Configure mock to raise exception for plural translations
-        with patch("AndroidResourceTranslator.translate_plural_with_llm") as mock_translate_plural:
+        with patch(
+            "AndroidResourceTranslator.translate_plural_with_llm"
+        ) as mock_translate_plural:
             mock_translate_plural.side_effect = Exception("API error")
 
             # Create LLMConfig
             llm_config = LLMConfig(
-                provider=LLMProvider.OPENAI,
-                api_key="test_api_key",
-                model="test-model"
+                provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
             )
 
             # Execute and verify exception propagation
@@ -463,9 +468,7 @@ class TestAutoTranslation(unittest.TestCase):
 
         # Create LLMConfig
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="test_api_key",
-            model="test-model"
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
         )
 
         # Execute auto translation

--- a/sample_project/README.md
+++ b/sample_project/README.md
@@ -61,24 +61,23 @@ sample_project/
 See what translations are missing without making any changes:
 
 ```bash
-python app/AndroidResourceTranslator.py sample_project/
+python app/AndroidResourceTranslator.py sample_project/ --dry-run
 ```
 
-**Test 2: Auto-translate (Default: OpenRouter with Gemini)**
+**Test 2: Translate (Default: OpenRouter with Gemini)**
 
 Automatically translate all missing strings using the default provider and model:
 
 ```bash
-python app/AndroidResourceTranslator.py sample_project/ --auto-translate
+python app/AndroidResourceTranslator.py sample_project/
 ```
 
-**Test 3: Auto-translate with OpenAI**
+**Test 3: Translate with OpenAI**
 
 Use OpenAI instead of the default OpenRouter:
 
 ```bash
 python app/AndroidResourceTranslator.py sample_project/ \
-    --auto-translate \
     --llm-provider openai \
     --model gpt-4o-mini
 ```
@@ -89,7 +88,6 @@ Provide additional context for better translations:
 
 ```bash
 python app/AndroidResourceTranslator.py sample_project/ \
-    --auto-translate \
     --project-context "A shopping list mobile application for groceries and household items"
 ```
 
@@ -99,7 +97,6 @@ Enable verbose output for debugging:
 
 ```bash
 python app/AndroidResourceTranslator.py sample_project/ \
-    --auto-translate \
     --log-trace
 ```
 
@@ -115,7 +112,7 @@ python app/AndroidResourceTranslator.py <path> [options]
 
 | Option                              | Description                               | Default                                     |
 | ----------------------------------- | ----------------------------------------- | ------------------------------------------- |
-| `--auto-translate`, `-a`        | Enable automatic translation              | `False`                                   |
+| `--dry-run`, `-d`               | Only report missing translations (don't translate) | `False`                              |
 | `--validate-translations`, `-v` | Manually validate each translation        | `False`                                   |
 | `--log-trace`, `-l`             | Enable detailed logging                   | `False`                                   |
 | `--llm-provider`                  | LLM provider:`openai` or `openrouter` | `openrouter`                              |
@@ -150,7 +147,7 @@ See [OpenRouter Models](https://openrouter.ai/docs/models) for the complete list
 
 ### Dry Run Output
 
-When you run without `--auto-translate`, you'll see a report like:
+When you run in dry-run mode (`--dry-run`), you'll see a report like:
 
 ```
 Found 1 module(s) with resources


### PR DESCRIPTION
This pull request updates the translation tool to replace the `auto_translate` option with a new `dry_run` mode, improving clarity and usability for users who only want to check for missing translations without performing actual translation. The changes affect documentation, configuration, and command-line interface, ensuring consistency across the project.

**Documentation and configuration updates:**

* Updated `README.md` to describe the new `--dry-run` option and removed references to `--auto-translate`, clarifying usage for both local runs and GitHub Actions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R116) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R125)
* Changed the `action.yml` input from `auto_translate` to `dry_run`, including updated descriptions and default values.

**Command-line and environment variable changes:**

* Refactored `AndroidResourceTranslator.py` to use `dry_run` instead of `auto_translate` throughout environment variable handling, argument parsing, and logging output. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1436-R1437) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1483-R1483) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1497-R1500) [[4]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1588-R1588) [[5]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1619-R1633)

**Translation logic adjustment:**

* Updated translation logic to only require an API key and run translation when not in dry-run mode, otherwise just reporting missing translations. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1619-R1633) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1691-R1692) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1736-R1736)