### PR TITLE
feat: Add reference context options for translation with existing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ jobs:
           #ignore_folders: "build" # Default will follow .gitignore
           #project_context: "Your project context here" # (Default is no context)
           #openrouter_send_site_info: "false" # Set to false to disable sending site info to OpenRouter
+          #include_reference_context: "false" # Disable sharing existing translations as prompt context
+          #reference_context_limit: "10" # Reduce or increase how many examples are sent
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
@@ -130,6 +132,8 @@ The action supports the following inputs:
 | **openrouter_send_site_info** | Send site URL and name to OpenRouter for rankings. Set to `"false"` to disable.                                                                                                                                                               | `"true"`                                                               | Yes      | `"true"` or `"false"`                                                  |
 | **project_context**          | Additional project context to include in translation prompts.                                                                                                                                                                                 | `""`                                                                   | Yes      | `"Android launcher application"`                                       |
 | **ignore_folders**           | Comma-separated list of folder names to ignore during resource scanning. If empty, .gitignore file will be used instead.                                                                                                                     | `""`                                                                   | Yes      | `"build,temp,cache"`                                                   |
+| **include_reference_context** | Include existing translations from the destination language as context when prompting the LLM. Set to `"false"` to disable the extra context entirely.                                                                                       | `"true"`                                                               | Yes      | `"false"`                                                              |
+| **reference_context_limit**  | Maximum number of existing translations to send as context examples. Use `"0"` to skip sending any reference strings even if context is enabled.                                                                                               | `"25"`                                                                 | Yes      | `"10"`                                                                 |
 
 ### Environment Variables (API Keys)
 

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: "Comma-separated list of folder names to ignore during resource scanning (e.g., build)."
     required: false
     default: ""
+  include_reference_context:
+    description: "Include existing translations from the target language as context for the LLM. Set to 'false' to disable."
+    required: false
+    default: "true"
+  reference_context_limit:
+    description: "Maximum number of existing translations to include as context (0 disables context)."
+    required: false
+    default: "25"
 
 outputs:
   translation_report:

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -6,7 +6,6 @@ This script scans Android resource files (strings.xml) for string and plural res
 reports missing translations, and can automatically translate missing entries using OpenAI.
 """
 
-import argparse
 import logging
 import sys
 import re
@@ -1617,6 +1616,8 @@ def main() -> None:
         startup_message_prefix = "Running with parameters from environment variables."
 
     else:
+        import argparse
+
         parser = argparse.ArgumentParser(description="Android Resource Translator")
         parser.add_argument(
             "resources_paths",

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -1768,7 +1768,7 @@ def main() -> None:
         )
         reference_context_limit = 0
 
-    include_reference_context = (
+    should_include_reference_context = (
         include_reference_context and reference_context_limit > 0
     )
 
@@ -1777,7 +1777,7 @@ def main() -> None:
         f"Log Trace: {log_trace}, "
         f"LLM Provider: {llm_provider}, Model: {model}, "
         f"Project Context: {project_context}, Ignore Folders: {ignore_folders}, "
-        f"Include Reference Context: {include_reference_context}, "
+        f"Include Reference Context: {should_include_reference_context}, "
         f"Reference Context Limit: {reference_context_limit}"
     )
     if startup_message_prefix:
@@ -1882,7 +1882,7 @@ def main() -> None:
             merged_modules,
             llm_config,
             project_context,
-            include_reference_context=include_reference_context,
+            include_reference_context=should_include_reference_context,
             reference_context_limit=reference_context_limit,
         )
 

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -869,7 +869,7 @@ def _build_reference_plural_examples(
         A list of dictionaries containing plural name, default values,
         and existing translations.
     """
-    examples: List[Dict[str, Dict[str, Dict[str, str]]]] = []
+    examples: List[Dict[str, Any]] = []
 
     for plural_name in sorted(res.plurals.keys()):
         if plural_name in exclude_names:
@@ -1548,8 +1548,6 @@ def main() -> None:
     Parses command-line arguments or environment variables, finds resource files,
     checks for missing translations, and auto-translates them.
     """
-    startup_message_prefix = ""
-
     is_github = os.environ.get("GITHUB_ACTIONS", "false").lower() == "true"
     if is_github:
         resources_paths_input = os.environ.get("INPUT_RESOURCES_PATHS")

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -6,13 +6,14 @@ This script scans Android resource files (strings.xml) for string and plural res
 reports missing translations, and can automatically translate missing entries using OpenAI.
 """
 
+import argparse
 import logging
 import sys
 import re
 import os
 from pathlib import Path
 from collections import defaultdict
-from typing import Dict, Set, List, Tuple
+from typing import Any, Dict, Set, List, Tuple
 from lxml import etree
 from language_utils import get_language_name
 
@@ -38,6 +39,8 @@ from llm_provider import (
 
 # Maximum number of items to translate in a single batch API call
 MAX_BATCH_SIZE = 100
+# Default number of existing translation pairs/plurals to include as context
+DEFAULT_REFERENCE_CONTEXT_LIMIT = 25
 
 TRANSLATION_GUIDELINES = """\
 Follow these guidelines carefully.
@@ -803,6 +806,95 @@ def escape_special_chars(text: str) -> str:
 # ------------------------------------------------------------------------------
 
 
+def _build_reference_string_examples(
+    res: "AndroidResourceFile",
+    default_strings: Dict[str, str],
+    exclude_keys: Set[str],
+    limit: int,
+) -> List[Dict[str, str]]:
+    """
+    Collect previously translated string examples for context.
+
+    Args:
+        res: Target language resource file.
+        default_strings: Dictionary of default language strings.
+        exclude_keys: Keys currently being translated (omit from context).
+        limit: Maximum number of examples to include.
+
+    Returns:
+        A list of dictionaries containing key, source, and existing translation.
+    """
+    examples: List[Dict[str, str]] = []
+
+    for key in sorted(res.strings.keys()):
+        if key in exclude_keys:
+            continue
+
+        source_text = default_strings.get(key)
+        translation_text = res.strings.get(key)
+
+        if not source_text or not translation_text:
+            continue
+
+        examples.append(
+            {
+                "key": key,
+                "source": source_text,
+                "existing_translation": translation_text,
+            }
+        )
+
+        if len(examples) >= limit:
+            break
+
+    return examples
+
+
+def _build_reference_plural_examples(
+    res: "AndroidResourceFile",
+    default_plurals: Dict[str, Dict[str, str]],
+    exclude_names: Set[str],
+    limit: int,
+) -> List[Dict[str, Any]]:
+    """
+    Collect previously translated plural examples for context.
+
+    Args:
+        res: Target language resource file.
+        default_plurals: Default language plural definitions.
+        exclude_names: Plural resource names currently being translated.
+        limit: Maximum number of examples to include.
+
+    Returns:
+        A list of dictionaries containing plural name, default values,
+        and existing translations.
+    """
+    examples: List[Dict[str, Dict[str, Dict[str, str]]]] = []
+
+    for plural_name in sorted(res.plurals.keys()):
+        if plural_name in exclude_names:
+            continue
+
+        default_quantities = default_plurals.get(plural_name)
+        existing_quantities = res.plurals.get(plural_name)
+
+        if not default_quantities or not existing_quantities:
+            continue
+
+        examples.append(
+            {
+                "plural_name": plural_name,
+                "source": dict(sorted(default_quantities.items())),
+                "existing_translation": dict(sorted(existing_quantities.items())),
+            }
+        )
+
+        if len(examples) >= limit:
+            break
+
+    return examples
+
+
 def _translate_missing_strings(
     res: AndroidResourceFile,
     missing_strings: set,
@@ -810,6 +902,8 @@ def _translate_missing_strings(
     lang: str,
     llm_config: LLMConfig,
     project_context: str,
+    include_reference_context: bool,
+    reference_context_limit: int,
 ) -> List[Dict]:
     """
     Helper function to translate missing strings for a resource file.
@@ -822,6 +916,8 @@ def _translate_missing_strings(
         lang: Target language code
         llm_config: LLM provider configuration
         project_context: Optional project context
+        include_reference_context: Whether to include existing translations as context
+        reference_context_limit: Maximum number of reference examples to include
 
     Returns:
         List of translation result dictionaries
@@ -870,14 +966,28 @@ def _translate_missing_strings(
             f"Translating batch of {len(chunk_dict)} strings (chunk {i // MAX_BATCH_SIZE + 1})"
         )
 
+        reference_examples: List[Dict[str, str]] = []
+        if include_reference_context and reference_context_limit > 0:
+            reference_examples = _build_reference_string_examples(
+                res=res,
+                default_strings=module_default_strings,
+                exclude_keys=set(chunk_keys),
+                limit=reference_context_limit,
+            )
+
+        translate_kwargs = {
+            "strings_dict": chunk_dict,
+            "system_message": system_message,
+            "user_prompt": base_prompt,
+            "llm_config": llm_config,
+        }
+
+        if include_reference_context and reference_examples:
+            translate_kwargs["reference_examples"] = reference_examples
+
         try:
             # Translate the entire batch
-            translations = translate_strings_batch_with_llm(
-                strings_dict=chunk_dict,
-                system_message=system_message,
-                user_prompt=base_prompt,
-                llm_config=llm_config,
-            )
+            translations = translate_strings_batch_with_llm(**translate_kwargs)
 
             # Process results
             for key, translated in translations.items():
@@ -913,9 +1023,12 @@ def _translate_missing_strings(
 def _translate_missing_plurals(
     res: AndroidResourceFile,
     missing_plurals: Dict[str, Dict[str, str]],
+    module_default_plurals: Dict[str, Dict[str, str]],
     lang: str,
     llm_config: LLMConfig,
     project_context: str,
+    include_reference_context: bool,
+    reference_context_limit: int,
 ) -> List[Dict]:
     """
     Helper function to translate missing plurals for a resource file.
@@ -924,9 +1037,12 @@ def _translate_missing_plurals(
     Args:
         res: Resource file to update
         missing_plurals: Dict of missing plural resources {name: {quantity: text}}
+        module_default_plurals: Dict of default plurals for the module
         lang: Target language code
         llm_config: LLM provider configuration
         project_context: Optional project context
+        include_reference_context: Whether to include existing translations as context
+        reference_context_limit: Maximum number of reference examples to include
 
     Returns:
         List of translation result dictionaries
@@ -965,14 +1081,28 @@ def _translate_missing_plurals(
             f"Translating batch of {len(chunk_dict)} plurals (chunk {i // MAX_BATCH_SIZE + 1})"
         )
 
+        reference_examples: List[Dict[str, Any]] = []
+        if include_reference_context and reference_context_limit > 0:
+            reference_examples = _build_reference_plural_examples(
+                res=res,
+                default_plurals=module_default_plurals,
+                exclude_names=set(chunk_names),
+                limit=reference_context_limit,
+            )
+
+        translate_kwargs = {
+            "plurals_dict": chunk_dict,
+            "system_message": system_message,
+            "user_prompt": base_prompt,
+            "llm_config": llm_config,
+        }
+
+        if include_reference_context and reference_examples:
+            translate_kwargs["reference_examples"] = reference_examples
+
         try:
             # Translate the entire batch
-            translations = translate_plurals_batch_with_llm(
-                plurals_dict=chunk_dict,
-                system_message=system_message,
-                user_prompt=base_prompt,
-                llm_config=llm_config,
-            )
+            translations = translate_plurals_batch_with_llm(**translate_kwargs)
 
             # Process results
             for plural_name, generated_plural in translations.items():
@@ -1076,6 +1206,8 @@ def auto_translate_resources(
     modules: Dict[str, AndroidModule],
     llm_config: LLMConfig,
     project_context: str,
+    include_reference_context: bool = True,
+    reference_context_limit: int = DEFAULT_REFERENCE_CONTEXT_LIMIT,
 ) -> dict:
     """
     For each non-default language resource, auto-translate missing strings and plural items.
@@ -1144,6 +1276,8 @@ def auto_translate_resources(
                         lang,
                         llm_config,
                         project_context,
+                        include_reference_context,
+                        reference_context_limit,
                     )
                     translation_log[module.name][lang]["strings"].extend(string_results)
                     total_translated += len(string_results)
@@ -1153,9 +1287,12 @@ def auto_translate_resources(
                     plural_results = _translate_missing_plurals(
                         res,
                         missing_plurals,
+                        module_default_plurals,
                         lang,
                         llm_config,
                         project_context,
+                        include_reference_context,
+                        reference_context_limit,
                     )
                     translation_log[module.name][lang]["plurals"].extend(plural_results)
                     total_translated += sum(
@@ -1411,7 +1548,7 @@ def main() -> None:
     Parses command-line arguments or environment variables, finds resource files,
     checks for missing translations, and auto-translates them.
     """
-    import argparse
+    startup_message_prefix = ""
 
     is_github = os.environ.get("GITHUB_ACTIONS", "false").lower() == "true"
     if is_github:
@@ -1451,6 +1588,23 @@ def main() -> None:
         )
 
         project_context = os.environ.get("INPUT_PROJECT_CONTEXT", "")
+
+        include_reference_context = (
+            os.environ.get("INPUT_INCLUDE_REFERENCE_CONTEXT", "true").lower() == "true"
+        )
+        reference_context_limit_raw = os.environ.get(
+            "INPUT_REFERENCE_CONTEXT_LIMIT", str(DEFAULT_REFERENCE_CONTEXT_LIMIT)
+        )
+        try:
+            reference_context_limit = int(reference_context_limit_raw)
+        except ValueError:
+            print(
+                f"Invalid INPUT_REFERENCE_CONTEXT_LIMIT value "
+                f"('{reference_context_limit_raw}'); falling back to "
+                f"{DEFAULT_REFERENCE_CONTEXT_LIMIT}"
+            )
+            reference_context_limit = DEFAULT_REFERENCE_CONTEXT_LIMIT
+
         ignore_folders_input = os.environ.get("INPUT_IGNORE_FOLDERS", "")
         ignore_folders = (
             [
@@ -1462,13 +1616,7 @@ def main() -> None:
             else []
         )
 
-        print(
-            "Running with parameters from environment variables. "
-            f"Resources Paths: {resources_paths}, Dry Run: {dry_run}, "
-            f"Log Trace: {log_trace}, "
-            f"LLM Provider: {llm_provider}, Model: {model}, "
-            f"Project Context: {project_context}, Ignore Folders: {ignore_folders}"
-        )
+        startup_message_prefix = "Running with parameters from environment variables."
 
     else:
         parser = argparse.ArgumentParser(description="Android Resource Translator")
@@ -1559,6 +1707,25 @@ def main() -> None:
             help="Comma separated list of folder names to ignore during scanning. "
             "If empty, .gitignore patterns will be used instead.",
         )
+        parser.add_argument(
+            "--include-reference-context",
+            dest="include_reference_context",
+            action="store_true",
+            default=None,
+            help="Include existing translations as additional context for the LLM (enabled by default).",
+        )
+        parser.add_argument(
+            "--no-include-reference-context",
+            dest="include_reference_context",
+            action="store_false",
+            help="Disable sending existing translations as context to the LLM.",
+        )
+        parser.add_argument(
+            "--reference-context-limit",
+            type=int,
+            default=DEFAULT_REFERENCE_CONTEXT_LIMIT,
+            help="Maximum number of existing translations to include as context (0 disables context).",
+        )
 
         args = parser.parse_args()
 
@@ -1581,19 +1748,43 @@ def main() -> None:
         openrouter_send_site_info = args.openrouter_send_site_info
 
         project_context = args.project_context
+        include_reference_context = (
+            args.include_reference_context
+            if args.include_reference_context is not None
+            else True
+        )
+        reference_context_limit = args.reference_context_limit
         ignore_folders = [
             folder.strip()
             for folder in args.ignore_folders.split(",")
             if folder.strip()
         ]
         # Don't print args because it will come with the API KEY
+        startup_message_prefix = "Running with command-line parameters."
+
+    if reference_context_limit < 0:
         print(
-            "Running with command-line parameters. "
-            f"Resources Paths: {resources_paths}, Dry Run: {dry_run}, "
-            f"Log Trace: {log_trace}, "
-            f"LLM Provider: {llm_provider}, Model: {model}, "
-            f"Project Context: {project_context}, Ignore Folders: {ignore_folders}"
+            f"Reference context limit {reference_context_limit} is negative; "
+            "resetting to 0 (disables context)."
         )
+        reference_context_limit = 0
+
+    include_reference_context = (
+        include_reference_context and reference_context_limit > 0
+    )
+
+    runtime_details = (
+        f"Resources Paths: {resources_paths}, Dry Run: {dry_run}, "
+        f"Log Trace: {log_trace}, "
+        f"LLM Provider: {llm_provider}, Model: {model}, "
+        f"Project Context: {project_context}, Ignore Folders: {ignore_folders}, "
+        f"Include Reference Context: {include_reference_context}, "
+        f"Reference Context Limit: {reference_context_limit}"
+    )
+    if startup_message_prefix:
+        print(f"{startup_message_prefix} {runtime_details}")
+    else:
+        print(runtime_details)
 
     configure_logging(log_trace)
 
@@ -1692,6 +1883,8 @@ def main() -> None:
             merged_modules,
             llm_config,
             project_context,
+            include_reference_context=include_reference_context,
+            reference_context_limit=reference_context_limit,
         )
 
     # Whether or not auto-translation was performed, still check for missing translations.

--- a/app/tests/test_integration.py
+++ b/app/tests/test_integration.py
@@ -130,6 +130,11 @@ class TestResourceFindingAndTranslation(TestIntegration):
         mock_translate_batch.assert_called_once()
         batch_kwargs = mock_translate_batch.call_args.kwargs
         self.assertIn("welcome", batch_kwargs.get("strings_dict", {}))
+        reference_examples = batch_kwargs.get("reference_examples")
+        self.assertIsNotNone(reference_examples)
+        self.assertTrue(
+            any(example.get("key") == "app_name" for example in reference_examples)
+        )
 
         # Verify resource was updated
         self.assertIn("welcome", es_res.strings)

--- a/app/tests/test_translation.py
+++ b/app/tests/test_translation.py
@@ -245,6 +245,19 @@ class TestAutoTranslation(unittest.TestCase):
         )
         self.assertEqual(strings_payload, {"goodbye": "Goodbye"})
 
+        reference_examples = mock_translate_strings_batch.call_args.kwargs.get(
+            "reference_examples"
+        )
+        self.assertIsNotNone(reference_examples)
+        self.assertIn(
+            {
+                "key": "hello",
+                "source": "Hello World",
+                "existing_translation": "Hola Mundo",
+            },
+            reference_examples,
+        )
+
         mock_translate_plurals_batch.assert_called_once()
         plurals_payload = (
             mock_translate_plurals_batch.call_args.kwargs.get("plurals_dict")
@@ -252,6 +265,9 @@ class TestAutoTranslation(unittest.TestCase):
         )
         self.assertEqual(
             plurals_payload, {"days": {"one": "%d day", "other": "%d days"}}
+        )
+        self.assertIsNone(
+            mock_translate_plurals_batch.call_args.kwargs.get("reference_examples")
         )
 
         # Verify file updates


### PR DESCRIPTION
This pull request introduces a new feature to the translation workflow: the ability to include existing translations as reference context in prompts to the LLM, both for string and plural resources. This aims to improve translation quality by providing the model with relevant examples, and is configurable via new inputs and command-line options. The changes also add robust configuration and validation for this feature, update documentation, and refactor translation batching logic to support passing reference examples.

Configuration and documentation updates:

* Added `include_reference_context` and `reference_context_limit` options to `README.md` and `action.yml`, allowing users to control whether and how many existing translations are sent as context to the LLM. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R136) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R56-R63)

Translation batching and context logic:

* Implemented `_build_reference_string_examples` and `_build_reference_plural_examples` helpers in `AndroidResourceTranslator.py` to collect existing translations for use as context, and updated batching logic to conditionally include these examples in LLM requests. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R809-R906) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R969-R990) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1084-R1105)

Main script and argument handling:

* Extended the main entrypoint to accept new environment variables and command-line arguments for reference context options, including validation and defaulting logic. Startup messages now include reference context details. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1414-L1415) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1589-R1605) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1465-R1617) [[4]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1708-R1726) [[5]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1749-R1785)

Translation workflow integration:

* Updated `auto_translate_resources`, `_translate_missing_strings`, and `_translate_missing_plurals` to support the new context options and ensure they are passed through all relevant function calls. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1209-R1210) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1279-R1280) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1290-R1295) [[4]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1884-R1885)

Minor improvements and code cleanup:

* Minor refactoring in imports, logging, and argument parsing to support new features and improve maintainability. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R9-R16) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R42-R43) [[3]](diffhunk://#diff-4ce84a16a6ceedf36b270b110336c989edf3d290881bf5f19e278a6a0a131b49L13-R13) [[4]](diffhunk://#diff-4ce84a16a6ceedf36b270b110336c989edf3d290881bf5f19e278a6a0a131b49L394-R396)