### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release-notes-generator.yml
+++ b/.github/workflows/release-notes-generator.yml
@@ -18,13 +18,13 @@ jobs:
       PIP_PROGRESS_BAR: 'off'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for release notes generation by upgrading the versions of key actions to ensure compatibility and benefit from the latest improvements.

Dependency updates:

* Updated the `actions/checkout` action from version `v4` to `v5` in `.github/workflows/release-notes-generator.yml` for improved performance and security.
* Updated the `actions/setup-python` action from version `v5` to `v6` in `.github/workflows/release-notes-generator.yml` to use the latest Python setup features.