### PR TITLE
refactor: Improve error handling for incomplete translations in LLM provider

### DIFF
--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -669,13 +669,14 @@ def translate_strings_batch_with_llm(
     # Validate that we got translations for all requested keys
     missing_keys = set(strings_dict.keys()) - set(translations.keys())
     if missing_keys:
-        logger.warning(
-            f"LLM did not provide translations for some keys: {missing_keys}. "
-            f"Using empty strings for missing translations."
+        logger.error(
+            "LLM did not provide translations for some keys: %s",
+            sorted(missing_keys),
         )
-        # Fill in missing translations with empty strings
-        for key in missing_keys:
-            translations[key] = ""
+        raise ValueError(
+            "LLM returned an incomplete translations array. Missing keys: "
+            + ", ".join(sorted(missing_keys))
+        )
 
     return translations
 

--- a/app/llm_provider.py
+++ b/app/llm_provider.py
@@ -591,6 +591,8 @@ def translate_strings_batch_with_llm(
         Dictionary mapping string keys to translated texts
 
     Raises:
+        ValueError: If the LLM returns an empty translations array or omits any
+                    requested keys from the batch result
         Exception: For any API-related errors
     """
     if not strings_dict:

--- a/app/tests/test_translation.py
+++ b/app/tests/test_translation.py
@@ -25,7 +25,7 @@ from string_utils import (
     escape_double_quotes,
     escape_special_chars,
 )
-from llm_provider import LLMConfig, LLMProvider
+from llm_provider import LLMConfig, LLMProvider, translate_strings_batch_with_llm
 
 
 class TestSpecialCharacterEscaping(unittest.TestCase):
@@ -280,6 +280,59 @@ class TestAutoTranslation(unittest.TestCase):
         self.assertIn("es", result["test_module"])
         self.assertIn("strings", result["test_module"]["es"])
         self.assertIn("plurals", result["test_module"]["es"])
+
+    @patch("AndroidResourceTranslator.translate_strings_batch_with_llm")
+    @patch("AndroidResourceTranslator.update_xml_file")
+    def test_auto_translate_raises_on_incomplete_batch_response(
+        self,
+        mock_update_xml,
+        mock_translate_strings_batch,
+    ):
+        """Partial string batches should fail instead of writing empty values."""
+        mock_translate_strings_batch.side_effect = ValueError(
+            "LLM returned an incomplete translations array. Missing keys: goodbye"
+        )
+
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
+        )
+
+        with self.assertRaisesRegex(ValueError, "Missing keys: goodbye"):
+            auto_translate_resources(
+                self.modules,
+                llm_config=llm_config,
+                project_context="Test project",
+            )
+
+        self.assertNotIn("goodbye", self.es_resource.strings)
+        mock_update_xml.assert_not_called()
+
+
+class TestBatchTranslationSafety(unittest.TestCase):
+    """Tests for safe handling of incomplete batch responses."""
+
+    def test_translate_strings_batch_raises_on_missing_keys(self):
+        """The adapter should reject partial LLM batch results."""
+
+        class FakeClient:
+            def __init__(self, config):
+                self.config = config
+
+            def chat_completion(self, **kwargs):
+                return {"translations": [{"key": "hello", "translation": "Hola"}]}
+
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
+        )
+
+        with patch("llm_provider.LLMClient", FakeClient):
+            with self.assertRaisesRegex(ValueError, "Missing keys: goodbye"):
+                translate_strings_batch_with_llm(
+                    strings_dict={"hello": "Hello", "goodbye": "Goodbye"},
+                    system_message="System",
+                    user_prompt="Prompt",
+                    llm_config=llm_config,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request strengthens the handling and testing of incomplete translation responses from the LLM (Large Language Model). Now, if the LLM returns a partial translation batch (missing keys), the system will raise an error instead of silently filling in empty strings. New tests are added to ensure this behavior and to prevent writing partial translation results.

Error handling improvements:

* [`app/llm_provider.py`](diffhunk://#diff-4ce84a16a6ceedf36b270b110336c989edf3d290881bf5f19e278a6a0a131b49L672-L678): Changed the behavior in `translate_strings_batch_with_llm` to log an error and raise a `ValueError` if the LLM returns an incomplete translation batch, instead of filling missing translations with empty strings.

Testing enhancements:

* `app/tests/test_translation.py`: Added tests to verify that incomplete batch responses raise an error and do not write partial results. This includes:
  * A test for `auto_translate_resources` to ensure it does not write any translations if the batch is incomplete.
  * A test for `translate_strings_batch_with_llm` to confirm it raises a `ValueError` when the LLM response is missing keys.
* [`app/tests/test_translation.py`](diffhunk://#diff-9b93e37d02c1cab380a35e30f5cb6eaa032600ce1d7f1972d18ff3c437b4a041L28-R28): Imported `translate_strings_batch_with_llm` for direct testing.