### PR TITLE
fix: improve plural translation check to ensure not all default quantities are needed

### DIFF
--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -1231,14 +1231,14 @@ def _collect_language_translations(
 
 
 def _format_missing_translations(
-    missing_strings: Set[str], missing_plurals: Dict[str, Set[str]]
+    missing_strings: Set[str], missing_plural_groups: Set[str]
 ) -> str:
     """
     Format missing translations for logging.
 
     Args:
         missing_strings: Set of missing string keys
-        missing_plurals: Dict of missing plural names and quantities
+        missing_plural_groups: Set of missing plural resource names
 
     Returns:
         Formatted string describing what's missing
@@ -1248,11 +1248,8 @@ def _format_missing_translations(
     if missing_strings:
         parts.append(f"strings: {', '.join(sorted(missing_strings))}")
 
-    if missing_plurals:
-        plurals_part = ", ".join(
-            [f"{k}({', '.join(sorted(v))})" for k, v in missing_plurals.items()]
-        )
-        parts.append(f"plurals: {plurals_part}")
+    if missing_plural_groups:
+        parts.append(f"plural groups: {', '.join(sorted(missing_plural_groups))}")
 
     return " | ".join(parts)
 
@@ -1260,7 +1257,10 @@ def _format_missing_translations(
 def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
     """
     For each module, compare non-default language resources against the union of keys
-    in the default language. Checks for missing <string> keys and missing plural quantities.
+    in the default language. Checks for missing <string> keys and missing plural
+    resource groups. Plural quantity keys are language-specific, so existing
+    target plural groups are not flagged for having different quantities from
+    the default locale.
 
     Args:
         modules: Dictionary of module identifiers to AndroidModule objects
@@ -1297,21 +1297,21 @@ def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
 
             # Find what's missing
             missing_strings = default_strings - lang_strings
-            missing_plurals: Dict[str, Set[str]] = {}
+            missing_plural_groups: Set[str] = set()
 
-            for plural_name, def_qty in default_plural_quantities.items():
+            for plural_name in default_plural_quantities:
                 current_qty = lang_plural_quantities.get(plural_name, set())
                 if not current_qty:
-                    missing_plurals[plural_name] = def_qty
+                    missing_plural_groups.add(plural_name)
 
             # Log and report if anything is missing
-            if missing_strings or missing_plurals:
+            if missing_strings or missing_plural_groups:
                 missing_count += 1
                 module_has_missing = True
 
                 # Format for logging
                 missing_description = _format_missing_translations(
-                    missing_strings, missing_plurals
+                    missing_strings, missing_plural_groups
                 )
                 module_log_lines.append(f"  [{lang}]: missing {missing_description}")
 
@@ -1320,10 +1320,8 @@ def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
                     missing_report[module.name] = {}
                 missing_report[module.name][lang] = {
                     "strings": list(missing_strings),
-                    "plurals": {
-                        name: list(quantities)
-                        for name, quantities in missing_plurals.items()
-                    },
+                    "plural_groups": sorted(missing_plural_groups),
+                    "plurals": {},
                 }
 
         # Log for this module

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -1114,9 +1114,12 @@ def auto_translate_resources(
                 missing_plurals = {}
                 for plural_name, default_map in module_default_plurals.items():
                     current_map = res.plurals.get(plural_name, {})
-                    if not current_map or set(current_map.keys()) != set(
-                        default_map.keys()
-                    ):
+
+                    # Treat an existing plural resource as complete regardless of the
+                    # specific quantity keys it contains. Plural categories are
+                    # language-specific, so the default locale's keys are not a safe
+                    # completeness contract for every target language.
+                    if not current_map:
                         missing_plurals[plural_name] = default_map
 
                 # Skip if nothing to translate
@@ -1298,9 +1301,8 @@ def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
 
             for plural_name, def_qty in default_plural_quantities.items():
                 current_qty = lang_plural_quantities.get(plural_name, set())
-                diff = def_qty - current_qty
-                if diff:
-                    missing_plurals[plural_name] = diff
+                if not current_qty:
+                    missing_plurals[plural_name] = def_qty
 
             # Log and report if anything is missing
             if missing_strings or missing_plurals:

--- a/app/tests/test_report.py
+++ b/app/tests/test_report.py
@@ -171,6 +171,35 @@ class TestReporting(unittest.TestCase):
         )
         self.assertIn("items", missing_report["test_module"]["es"]["plurals"])
 
+    @patch("AndroidResourceTranslator.AndroidResourceFile.parse_file")
+    def test_check_missing_translations_does_not_require_source_plural_keys(
+        self, mock_parse_file
+    ):
+        """Plural completeness should not be inferred from source quantity keys."""
+        modules = {}
+        module = AndroidModule("test_module")
+
+        default_res = AndroidResourceFile(Path("dummy/path"), "default")
+        default_res.strings = {}
+        default_res.plurals = {
+            "days": {"one": "%d day", "few": "%d days", "other": "%d days"}
+        }
+
+        pt_res = AndroidResourceFile(Path("dummy/path"), "pt")
+        pt_res.strings = {}
+        pt_res.plurals = {"days": {"other": "%d dias"}}
+
+        module.language_resources["default"] = [default_res]
+        module.language_resources["pt"] = [pt_res]
+        modules["test_module"] = module
+
+        with self.assertLogs(level="INFO") as cm:
+            missing_report = check_missing_translations(modules)
+
+        log_output = "\n".join(cm.output)
+        self.assertIn("All translations are complete", log_output)
+        self.assertEqual(missing_report, {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/tests/test_report.py
+++ b/app/tests/test_report.py
@@ -161,6 +161,7 @@ class TestReporting(unittest.TestCase):
         self.assertIn("welcome", log_output)
         self.assertIn("cancel", log_output)
         self.assertIn("items", log_output)
+        self.assertIn("plural groups: items", log_output)
 
         # Verify missing report structure
         self.assertIn("test_module", missing_report)
@@ -169,7 +170,8 @@ class TestReporting(unittest.TestCase):
             sorted(missing_report["test_module"]["es"]["strings"]),
             ["cancel", "welcome"],
         )
-        self.assertIn("items", missing_report["test_module"]["es"]["plurals"])
+        self.assertEqual(missing_report["test_module"]["es"]["plural_groups"], ["items"])
+        self.assertEqual(missing_report["test_module"]["es"]["plurals"], {})
 
     @patch("AndroidResourceTranslator.AndroidResourceFile.parse_file")
     def test_check_missing_translations_does_not_require_source_plural_keys(

--- a/app/tests/test_translation.py
+++ b/app/tests/test_translation.py
@@ -281,6 +281,98 @@ class TestAutoTranslation(unittest.TestCase):
         self.assertIn("strings", result["test_module"]["es"])
         self.assertIn("plurals", result["test_module"]["es"])
 
+    @patch("AndroidResourceTranslator.translate_plurals_batch_with_llm")
+    @patch("AndroidResourceTranslator.translate_strings_batch_with_llm")
+    @patch("AndroidResourceTranslator.update_xml_file")
+    def test_auto_translate_skips_plurals_when_target_has_extra_valid_forms(
+        self,
+        mock_update_xml,
+        mock_translate_strings_batch,
+        mock_translate_plurals_batch,
+    ):
+        """Extra locale-specific plural forms should not trigger retranslation."""
+        module = AndroidModule("test_module", "test_id")
+
+        default_resource = MagicMock()
+        default_resource.strings = {}
+        default_resource.plurals = {"days": {"other": "%d days"}}
+        default_resource.modified = False
+
+        sv_resource = MagicMock()
+        sv_resource.strings = {}
+        sv_resource.plurals = {
+            "days": {
+                "one": "%d dag",
+                "few": "%d dagar",
+                "other": "%d dagar",
+            }
+        }
+        sv_resource.modified = False
+
+        module.add_resource("default", default_resource)
+        module.add_resource("sv", sv_resource)
+
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
+        )
+
+        result = auto_translate_resources(
+            {"test_id": module},
+            llm_config=llm_config,
+            project_context="Test project",
+        )
+
+        mock_translate_strings_batch.assert_not_called()
+        mock_translate_plurals_batch.assert_not_called()
+        mock_update_xml.assert_not_called()
+        self.assertFalse(sv_resource.modified)
+        self.assertEqual(sv_resource.plurals["days"]["few"], "%d dagar")
+        self.assertEqual(result["test_module"]["sv"]["plurals"], [])
+
+    @patch("AndroidResourceTranslator.translate_plurals_batch_with_llm")
+    @patch("AndroidResourceTranslator.translate_strings_batch_with_llm")
+    @patch("AndroidResourceTranslator.update_xml_file")
+    def test_auto_translate_skips_existing_plural_when_target_only_has_other(
+        self,
+        mock_update_xml,
+        mock_translate_strings_batch,
+        mock_translate_plurals_batch,
+    ):
+        """A target plural that already exists should not be retransmitted."""
+        module = AndroidModule("test_module", "test_id")
+
+        default_resource = MagicMock()
+        default_resource.strings = {}
+        default_resource.plurals = {
+            "days": {"one": "%d day", "few": "%d days", "other": "%d days"}
+        }
+        default_resource.modified = False
+
+        target_resource = MagicMock()
+        target_resource.strings = {}
+        target_resource.plurals = {"days": {"other": "%d dias"}}
+        target_resource.modified = False
+
+        module.add_resource("default", default_resource)
+        module.add_resource("pt", target_resource)
+
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI, api_key="test_api_key", model="test-model"
+        )
+
+        result = auto_translate_resources(
+            {"test_id": module},
+            llm_config=llm_config,
+            project_context="Test project",
+        )
+
+        mock_translate_strings_batch.assert_not_called()
+        mock_translate_plurals_batch.assert_not_called()
+        mock_update_xml.assert_not_called()
+        self.assertFalse(target_resource.modified)
+        self.assertEqual(target_resource.plurals["days"], {"other": "%d dias"})
+        self.assertEqual(result["test_module"]["pt"]["plurals"], [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request improves the handling of plural resource translations in Android localization workflows, ensuring that plural completeness checks and auto-translation logic respect language-specific plural categories rather than relying on the source (default locale) plural keys. It also adds comprehensive tests to verify this behavior.

**Plural resource completeness logic:**

* The `auto_translate_resources` function now treats a plural resource as complete if it exists in the target language, regardless of whether its quantity keys match those in the default locale. This prevents unnecessary retranslation when locale-specific plural forms differ from the source.
* The `check_missing_translations` function only marks plural resources as missing if they are entirely absent in the target language, rather than requiring all source quantity keys to be present.

**Test coverage improvements:**

* Added tests to ensure that extra or missing plural forms in the target language do not trigger unnecessary translations, and that the presence of any plural form is sufficient to consider a resource complete. [[1]](diffhunk://#diff-9b93e37d02c1cab380a35e30f5cb6eaa032600ce1d7f1972d18ff3c437b4a041R284-R375) [[2]](diffhunk://#diff-633d20555599c948b0abc227266fecb3e908d1c5b9d7ff46d5c4f5c9624addf8R174-R202)

These changes make the translation process more robust and accurate for languages with different pluralization rules.