### PR TITLE
Fix: locale detection for Android resource folders

### DIFF
--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -354,14 +354,20 @@ def detect_language_from_path(file_path: Path) -> str:
       - "values-zh-rCN"    -> "zh-rCN" (Chinese Simplified)
       - "values-b+sr+Latn" -> "b+sr+Latn" (Serbian in Latin script)
 
-    The function tries to match the standard pattern first (values-XX),
-    and falls back to a simpler replacement if the pattern doesn't match.
+    The function accepts only Android locale qualifiers in standard form
+    (e.g., values-es, values-pt-rPT) or BCP 47 form (e.g., values-b+sr+Latn).
+    Non-locale configuration qualifiers such as values-night or values-v31 are
+    rejected.
 
     Args:
         file_path: Path object pointing to a resource file
 
     Returns:
         String representing the language code, or "default" for the base language
+
+    Raises:
+        ValueError: If the parent directory is not "values" or a valid locale
+                    resource directory.
     """
     values_dir = file_path.parent.name
 

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -147,6 +147,13 @@ Translate the following string provided after the dashed line to language: {targ
 
 logger = logging.getLogger(__name__)
 
+_STANDARD_LOCALE_QUALIFIER_PATTERN = re.compile(
+    r"^[a-z]{2,3}(?:-r(?:[A-Z]{2}|\d{3}))?$"
+)
+_BCP47_LOCALE_QUALIFIER_PATTERN = re.compile(
+    r"^b\+[A-Za-z]{2,3}(?:\+[A-Za-z]{4})?(?:\+(?:[A-Z]{2}|\d{3}))?$"
+)
+
 
 def _create_secure_fragment_parser() -> etree.XMLParser:
     """Return an XML parser configured to avoid external entity resolution."""
@@ -371,6 +378,16 @@ def detect_language_from_path(file_path: Path) -> str:
         )
 
     language = match.group(1)
+    if not (
+        _STANDARD_LOCALE_QUALIFIER_PATTERN.fullmatch(language)
+        or _BCP47_LOCALE_QUALIFIER_PATTERN.fullmatch(language)
+    ):
+        raise ValueError(
+            f"Invalid Android locale qualifier: '{values_dir}'. "
+            "Expected a locale folder such as 'values-es', 'values-pt-rPT', "
+            "or 'values-b+sr+Latn'."
+        )
+
     logger.debug(f"Detected language '{language}' from {values_dir}")
     return language
 
@@ -460,7 +477,15 @@ def find_resource_files(
             continue
 
         # Detect which language this resource file is for
-        language = detect_language_from_path(xml_file_path)
+        try:
+            language = detect_language_from_path(xml_file_path)
+        except ValueError:
+            logger.debug(
+                "Skipping %s because '%s' is not a locale resource directory",
+                xml_file_path,
+                xml_file_path.parent.name,
+            )
+            continue
 
         try:
             # Identify the module based on the project structure

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -431,9 +431,11 @@ def find_resource_files(
     # 2. Otherwise, use patterns from .gitignore files with proper precedence
     if ignore_folders:
         logger.info(f"Using explicit ignore folders: {', '.join(ignore_folders)}")
+        ignored_folder_names = set(ignore_folders)
         gitignore_patterns = []
         all_gitignores = {}
     else:
+        ignored_folder_names = set()
         # Find all .gitignore files in the directory hierarchy
         all_gitignores = find_all_gitignores(resources_path)
         if all_gitignores:
@@ -455,7 +457,7 @@ def find_resource_files(
     for xml_file_path in resources_dir.rglob("strings.xml"):
         # Skip files in ignored directories
         if ignore_folders and any(
-            ignored in str(xml_file_path.parts) for ignored in ignore_folders
+            path_part in ignored_folder_names for path_part in xml_file_path.parts
         ):
             logger.debug(f"Skipping {xml_file_path} (matched ignore_folders)")
             continue

--- a/app/AndroidResourceTranslator.py
+++ b/app/AndroidResourceTranslator.py
@@ -1053,8 +1053,10 @@ def _generate_translation_summary(translation_log: dict, total_translated: int) 
         return
 
     translated_info = {}
-    for module_name, lang_details in translation_log.items():
+    for lang_details in translation_log.values():
         for lang, details in lang_details.items():
+            if lang == "_module_name":
+                continue
             entry = translated_info.setdefault(
                 lang, {"strings": set(), "plurals": set()}
             )
@@ -1087,6 +1089,21 @@ def _generate_translation_summary(translation_log: dict, total_translated: int) 
         logger.info(" ".join(msg_parts))
 
 
+def _duplicate_module_names(modules: Dict[str, AndroidModule]) -> Set[str]:
+    """Return module short names that appear more than once."""
+    name_counts: Dict[str, int] = defaultdict(int)
+    for module in modules.values():
+        name_counts[module.name] += 1
+    return {name for name, count in name_counts.items() if count > 1}
+
+
+def _module_report_key(module: AndroidModule, duplicate_names: Set[str]) -> str:
+    """Use short names by default, falling back to unique identifiers for duplicates."""
+    if module.name in duplicate_names:
+        return module.identifier
+    return module.name
+
+
 def auto_translate_resources(
     modules: Dict[str, AndroidModule],
     llm_config: LLMConfig,
@@ -1105,6 +1122,7 @@ def auto_translate_resources(
     """
     translation_log = {}
     total_translated = 0
+    duplicate_names = _duplicate_module_names(modules)
 
     for module in modules.values():
         if "default" not in module.language_resources:
@@ -1118,13 +1136,17 @@ def auto_translate_resources(
             module
         )
 
+        module_report_key = _module_report_key(module, duplicate_names)
         # Process each non-default language
         for lang, resources in module.language_resources.items():
             if lang == "default":
                 continue
 
+            module_log = translation_log.setdefault(
+                module_report_key, {"_module_name": module.name}
+            )
             # Initialize translation log for this language
-            translation_log.setdefault(module.name, {})[lang] = {
+            module_log[lang] = {
                 "strings": [],
                 "plurals": [],
             }
@@ -1164,7 +1186,7 @@ def auto_translate_resources(
                         include_reference_context,
                         reference_context_limit,
                     )
-                    translation_log[module.name][lang]["strings"].extend(string_results)
+                    module_log[lang]["strings"].extend(string_results)
                     total_translated += len(string_results)
 
                 # Translate missing plurals
@@ -1179,7 +1201,7 @@ def auto_translate_resources(
                         include_reference_context,
                         reference_context_limit,
                     )
-                    translation_log[module.name][lang]["plurals"].extend(plural_results)
+                    module_log[lang]["plurals"].extend(plural_results)
                     total_translated += sum(
                         len(p["translations"]) for p in plural_results
                     )
@@ -1293,6 +1315,7 @@ def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
     logger.info("Missing Translations Report")
     missing_count = 0
     missing_report = {}
+    duplicate_names = _duplicate_module_names(modules)
 
     for module in modules.values():
         module_has_missing = False
@@ -1307,6 +1330,7 @@ def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
             module
         )
 
+        module_report_key = _module_report_key(module, duplicate_names)
         # Check each non-default language
         for lang, resources in sorted(module.language_resources.items()):
             if lang == "default":
@@ -1339,9 +1363,9 @@ def check_missing_translations(modules: Dict[str, AndroidModule]) -> dict:
                 module_log_lines.append(f"  [{lang}]: missing {missing_description}")
 
                 # Add to the report dictionary
-                if module.name not in missing_report:
-                    missing_report[module.name] = {}
-                missing_report[module.name][lang] = {
+                if module_report_key not in missing_report:
+                    missing_report[module_report_key] = {"_module_name": module.name}
+                missing_report[module_report_key][lang] = {
                     "strings": list(missing_strings),
                     "plurals": {
                         name: list(quantities)
@@ -1374,12 +1398,20 @@ def create_translation_report(translation_log):
     report = "# Translation Report\n\n"
     has_translations = False
 
-    for module, languages in translation_log.items():
+    for module_identifier, languages in translation_log.items():
         module_has_translations = False
-        module_report = f"## Module: {module}\n\n"
+        module_name = languages.get("_module_name", module_identifier)
+        if module_name == module_identifier:
+            module_heading = module_name
+        else:
+            module_heading = f"{module_name} ({module_identifier})"
+
+        module_report = f"## Module: {module_heading}\n\n"
         languages_report = ""
 
         for lang, details in languages.items():
+            if lang == "_module_name":
+                continue
             has_string_translations = bool(details.get("strings"))
             has_plural_translations = bool(details.get("plurals"))
 

--- a/app/tests/test_integration.py
+++ b/app/tests/test_integration.py
@@ -211,5 +211,55 @@ class TestFileUpdating(TestIntegration):
         self.assertIn('<item quantity="other">%d new items</item>', updated_content)
 
 
+class TestDuplicateModuleNames(TestIntegration):
+    """Integration coverage for modules sharing the same short name."""
+
+    @patch("AndroidResourceTranslator.translate_strings_batch_with_llm")
+    def test_duplicate_module_names_stay_separate_in_translation_log(
+        self, mock_translate_batch
+    ):
+        """Translation state should not collide when module names repeat."""
+        mock_translate_batch.return_value = {"hello": "Hola"}
+
+        for base in ["featureA/common", "featureB/common"]:
+            res_dir = os.path.join(self.temp_dir.name, base, "src", "main", "res")
+            os.makedirs(os.path.join(res_dir, "values"), exist_ok=True)
+            os.makedirs(os.path.join(res_dir, "values-es"), exist_ok=True)
+            with open(os.path.join(res_dir, "values", "strings.xml"), "w") as f:
+                f.write(
+                    """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="hello">Hello</string>
+</resources>"""
+                )
+            with open(os.path.join(res_dir, "values-es", "strings.xml"), "w") as f:
+                f.write(
+                    """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>"""
+                )
+
+        modules = find_resource_files(self.temp_dir.name)
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI, api_key="fake_api_key", model="fake_model"
+        )
+
+        with patch("AndroidResourceTranslator.update_xml_file"):
+            translation_log = auto_translate_resources(
+                modules,
+                llm_config=llm_config,
+                project_context="Test project",
+            )
+
+        self.assertEqual(len(translation_log), 2)
+        self.assertTrue(
+            all(entry.get("_module_name") == "common" for entry in translation_log.values())
+        )
+
+        report = create_translation_report(translation_log)
+        self.assertIn("featureA/common", report)
+        self.assertIn("featureB/common", report)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/app/tests/test_report.py
+++ b/app/tests/test_report.py
@@ -87,6 +87,44 @@ class TestReporting(unittest.TestCase):
         self.assertIn("### Language: French", report)
         self.assertIn("| hello | Hello World | Bonjour le monde |", report)
 
+    def test_create_translation_report_distinguishes_duplicate_module_names(self):
+        """Duplicate short names should render as separate module sections."""
+        translation_log = {
+            "/repo/featureA/common": {
+                "_module_name": "common",
+                "es": {
+                    "strings": [
+                        {
+                            "key": "hello",
+                            "source": "Hello",
+                            "translation": "Hola",
+                        }
+                    ],
+                    "plurals": [],
+                },
+            },
+            "/repo/featureB/common": {
+                "_module_name": "common",
+                "fr": {
+                    "strings": [
+                        {
+                            "key": "hello",
+                            "source": "Hello",
+                            "translation": "Bonjour",
+                        }
+                    ],
+                    "plurals": [],
+                },
+            },
+        }
+
+        report = create_translation_report(translation_log)
+
+        self.assertIn("## Module: common (/repo/featureA/common)", report)
+        self.assertIn("## Module: common (/repo/featureB/common)", report)
+        self.assertIn("| hello | Hello | Hola |", report)
+        self.assertIn("| hello | Hello | Bonjour |", report)
+
     @patch("AndroidResourceTranslator.AndroidResourceFile.parse_file")
     def test_check_missing_translations_none_missing(self, mock_parse_file):
         """Test checking for missing translations when all are present."""
@@ -170,6 +208,48 @@ class TestReporting(unittest.TestCase):
             ["cancel", "welcome"],
         )
         self.assertIn("items", missing_report["test_module"]["es"]["plurals"])
+
+    @patch("AndroidResourceTranslator.AndroidResourceFile.parse_file")
+    def test_check_missing_translations_keeps_duplicate_module_names_separate(
+        self, mock_parse_file
+    ):
+        """Missing-report state should be keyed by unique module identifier."""
+        modules = {}
+
+        module_a = AndroidModule("common", identifier="/repo/featureA/common")
+        default_a = AndroidResourceFile(Path("dummy/path"), "default")
+        default_a.strings = {"hello": "Hello"}
+        default_a.plurals = {}
+        es_a = AndroidResourceFile(Path("dummy/path"), "es")
+        es_a.strings = {}
+        es_a.plurals = {}
+        module_a.language_resources["default"] = [default_a]
+        module_a.language_resources["es"] = [es_a]
+        modules[module_a.identifier] = module_a
+
+        module_b = AndroidModule("common", identifier="/repo/featureB/common")
+        default_b = AndroidResourceFile(Path("dummy/path"), "default")
+        default_b.strings = {"bye": "Goodbye"}
+        default_b.plurals = {}
+        fr_b = AndroidResourceFile(Path("dummy/path"), "fr")
+        fr_b.strings = {}
+        fr_b.plurals = {}
+        module_b.language_resources["default"] = [default_b]
+        module_b.language_resources["fr"] = [fr_b]
+        modules[module_b.identifier] = module_b
+
+        missing_report = check_missing_translations(modules)
+
+        self.assertIn("/repo/featureA/common", missing_report)
+        self.assertIn("/repo/featureB/common", missing_report)
+        self.assertEqual(missing_report["/repo/featureA/common"]["_module_name"], "common")
+        self.assertEqual(missing_report["/repo/featureB/common"]["_module_name"], "common")
+        self.assertEqual(
+            missing_report["/repo/featureA/common"]["es"]["strings"], ["hello"]
+        )
+        self.assertEqual(
+            missing_report["/repo/featureB/common"]["fr"]["strings"], ["bye"]
+        )
 
 
 if __name__ == "__main__":

--- a/app/tests/test_resource_parser.py
+++ b/app/tests/test_resource_parser.py
@@ -233,6 +233,25 @@ class TestFindResourceFiles(TestResourceParser):
             "Should only find resources in values directory",
         )
 
+    def test_non_locale_values_qualifiers_are_ignored(self):
+        """Android config qualifiers like night/land should not be treated as locales."""
+        base_path = os.path.join(self.temp_dir, "module1", "src", "main", "res")
+        self.create_strings_xml(os.path.join(base_path, "values", "strings.xml"))
+        self.create_strings_xml(os.path.join(base_path, "values-es", "strings.xml"))
+        self.create_strings_xml(os.path.join(base_path, "values-night", "strings.xml"))
+        self.create_strings_xml(os.path.join(base_path, "values-land", "strings.xml"))
+        self.create_strings_xml(os.path.join(base_path, "values-v31", "strings.xml"))
+
+        modules = find_resource_files(self.temp_dir)
+
+        self.assertEqual(len(modules), 1, "Should find one module")
+        module = list(modules.values())[0]
+        self.assertIn("default", module.language_resources)
+        self.assertIn("es", module.language_resources)
+        self.assertNotIn("night", module.language_resources)
+        self.assertNotIn("land", module.language_resources)
+        self.assertNotIn("v31", module.language_resources)
+
 
 class TestLanguageDetection(TestResourceParser):
     """Tests for language detection from resource paths."""
@@ -286,6 +305,37 @@ class TestLanguageDetection(TestResourceParser):
             self.assertEqual(
                 detected_lang, expected_lang, f"Failed to detect language from {path}"
             )
+
+    def test_detect_language_from_path_rejects_non_locale_qualifiers(self):
+        """Non-locale values qualifiers should not be accepted as languages."""
+        invalid_paths = [
+            Path(self.temp_dir)
+            / "module1"
+            / "src"
+            / "main"
+            / "res"
+            / "values-night"
+            / "strings.xml",
+            Path(self.temp_dir)
+            / "module1"
+            / "src"
+            / "main"
+            / "res"
+            / "values-land"
+            / "strings.xml",
+            Path(self.temp_dir)
+            / "module1"
+            / "src"
+            / "main"
+            / "res"
+            / "values-v31"
+            / "strings.xml",
+        ]
+
+        for path in invalid_paths:
+            with self.subTest(path=path):
+                with self.assertRaisesRegex(ValueError, "Invalid Android locale qualifier"):
+                    detect_language_from_path(path)
 
 
 class TestResourceParsing(TestResourceParser):

--- a/app/tests/test_resource_parser.py
+++ b/app/tests/test_resource_parser.py
@@ -163,6 +163,37 @@ class TestFindResourceFiles(TestResourceParser):
             list(modules.values())[0].name, "module1", "Should only find module1"
         )
 
+    def test_ignore_folders_matches_exact_path_segments(self):
+        """Ignoring 'build' should not exclude paths like 'rebuild_module'."""
+        self.create_strings_xml(
+            os.path.join(
+                self.temp_dir,
+                "rebuild_module",
+                "src",
+                "main",
+                "res",
+                "values",
+                "strings.xml",
+            )
+        )
+        self.create_strings_xml(
+            os.path.join(
+                self.temp_dir,
+                "build",
+                "module2",
+                "src",
+                "main",
+                "res",
+                "values",
+                "strings.xml",
+            )
+        )
+
+        modules = find_resource_files(self.temp_dir, ignore_folders=["build"])
+
+        self.assertEqual(len(modules), 1, "Should find only the rebuild_module resource")
+        self.assertEqual(list(modules.values())[0].name, "rebuild_module")
+
     def test_gitignore_patterns(self):
         """Test that files matching gitignore patterns are skipped."""
         # Test gitignore pattern with explicit ignore_folders instead

--- a/app/tests/test_resource_parser.py
+++ b/app/tests/test_resource_parser.py
@@ -30,6 +30,30 @@ from AndroidResourceTranslator import (
 class TestResourceParser(unittest.TestCase):
     """Tests for Android resource file parsing functionality."""
 
+    VALID_RESOURCE_FOLDER_LANGUAGES = {
+        "values": "default",
+        "values-b+sr+Latn": "b+sr+Latn",
+        "values-ca": "ca",
+        "values-el": "el",
+        "values-es": "es",
+        "values-fi-rFI": "fi-rFI",
+        "values-hr": "hr",
+        "values-hu": "hu",
+        "values-it": "it",
+        "values-mr": "mr",
+        "values-nb-rNO": "nb-rNO",
+        "values-nl": "nl",
+        "values-pt": "pt",
+        "values-pt-rBR": "pt-rBR",
+        "values-ro": "ro",
+        "values-sr": "sr",
+        "values-sv-rSE": "sv-rSE",
+        "values-ta-rIN": "ta-rIN",
+        "values-vi": "vi",
+        "values-zh-rCN": "zh-rCN",
+        "values-zh-rTW": "zh-rTW",
+    }
+
     def setUp(self):
         """Set up a temporary directory for file-based tests."""
         self.temp_dir = tempfile.mkdtemp()
@@ -283,55 +307,42 @@ class TestFindResourceFiles(TestResourceParser):
         self.assertNotIn("land", module.language_resources)
         self.assertNotIn("v31", module.language_resources)
 
+    def test_find_resource_files_accepts_supported_locale_values_folders(self):
+        """All supported locale values folders should be discovered as languages."""
+        base_path = os.path.join(self.temp_dir, "module1", "src", "main", "res")
+        for folder_name in self.VALID_RESOURCE_FOLDER_LANGUAGES:
+            self.create_strings_xml(os.path.join(base_path, folder_name, "strings.xml"))
+
+        self.create_strings_xml(
+            os.path.join(base_path, "mipmap-mdpi", "strings.xml")
+        )
+
+        modules = find_resource_files(self.temp_dir)
+
+        self.assertEqual(len(modules), 1, "Should find one module")
+        module = list(modules.values())[0]
+        self.assertEqual(
+            set(module.language_resources.keys()),
+            set(self.VALID_RESOURCE_FOLDER_LANGUAGES.values()),
+        )
+        self.assertNotIn("mipmap-mdpi", module.language_resources)
+
 
 class TestLanguageDetection(TestResourceParser):
     """Tests for language detection from resource paths."""
 
     def test_detect_language_from_path(self):
         """Test language detection from resource directory names."""
-        test_cases = [
-            (
+        for folder_name, expected_lang in self.VALID_RESOURCE_FOLDER_LANGUAGES.items():
+            path = (
                 Path(self.temp_dir)
                 / "module1"
                 / "src"
                 / "main"
                 / "res"
-                / "values"
-                / "strings.xml",
-                "default",
-            ),
-            (
-                Path(self.temp_dir)
-                / "module1"
-                / "src"
-                / "main"
-                / "res"
-                / "values-es"
-                / "strings.xml",
-                "es",
-            ),
-            (
-                Path(self.temp_dir)
-                / "module1"
-                / "src"
-                / "main"
-                / "res"
-                / "values-zh-rCN"
-                / "strings.xml",
-                "zh-rCN",
-            ),
-            (
-                Path(self.temp_dir)
-                / "module1"
-                / "src"
-                / "main"
-                / "res"
-                / "values-b+sr+Latn"
-                / "strings.xml",
-                "b+sr+Latn",
-            ),
-        ]
-        for path, expected_lang in test_cases:
+                / folder_name
+                / "strings.xml"
+            )
             detected_lang = detect_language_from_path(path)
             self.assertEqual(
                 detected_lang, expected_lang, f"Failed to detect language from {path}"


### PR DESCRIPTION
This pull request enhances the robustness and correctness of Android resource translation and reporting, particularly when handling modules that share the same short name and when filtering valid locale directories. The changes ensure that modules with duplicate names are kept separate throughout translation, reporting, and missing translation checks, and that only valid locale qualifiers are recognized. The update also improves the precision of ignored folder matching and adds comprehensive tests for these scenarios.

**Handling of duplicate module names:**

* Introduced logic to detect and distinguish modules with duplicate short names by using unique identifiers as keys in translation logs and reports, ensuring translation and missing-translation states do not collide. This affects functions like `auto_translate_resources`, `check_missing_translations`, and `create_translation_report`, and adds helper functions `_duplicate_module_names` and `_module_report_key`. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1094-R1108) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1127) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1141-R1151) [[4]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1317-R1370) [[5]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1352-R1416) [[6]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1320) [[7]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R1335)
* Updated summary generation and reporting to use the new module keying, and adjusted the aggregation of translation information to prevent mixing data from modules with the same name. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1031-R1061) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L1352-R1416)

**Locale qualifier validation and filtering:**

* Added strict regular expressions to validate Android locale qualifiers, ensuring only valid locale resource directories (e.g., `values-es`, `values-pt-rPT`, `values-b+sr+Latn`) are accepted, and non-locale qualifiers (like `night`, `land`, `v31`) are ignored. The `detect_language_from_path` function now raises a `ValueError` for invalid qualifiers. [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R150-R156) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R381-R390) [[3]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R482-R490)

**Folder ignoring logic improvements:**

* Updated the resource file discovery logic to match ignored folders by exact path segments, preventing accidental exclusion of similarly named but unrelated directories (e.g., `build` vs. `rebuild_module`). [[1]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1R434-R438) [[2]](diffhunk://#diff-a7d6ca2d29dca546abc3ff885ec023d3c21616842949e8e58dcfcd372a39f9d1L441-R460)

**Test coverage enhancements:**

* Added integration and unit tests to verify that modules with duplicate names remain separate in translation logs and reports, and that only valid locale directories are processed. Tests also cover the improved ignore-folder matching and proper rejection of non-locale qualifiers. [[1]](diffhunk://#diff-93100268984eb2b0dbbaaf3b189af9a0509d95ddc1177b1d28dcce8cbee32e45R214-R263) [[2]](diffhunk://#diff-633d20555599c948b0abc227266fecb3e908d1c5b9d7ff46d5c4f5c9624addf8R90-R127) [[3]](diffhunk://#diff-633d20555599c948b0abc227266fecb3e908d1c5b9d7ff46d5c4f5c9624addf8R212-R253) [[4]](diffhunk://#diff-fe348c3a6ef49e40eb21376196fb0804464658b1be83f3a45641227d588473e6R166-R196) [[5]](diffhunk://#diff-fe348c3a6ef49e40eb21376196fb0804464658b1be83f3a45641227d588473e6R267-R285) [[6]](diffhunk://#diff-fe348c3a6ef49e40eb21376196fb0804464658b1be83f3a45641227d588473e6R340-R370)